### PR TITLE
Set port number to default

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Assuming you have an Ethereum node running the JSON RPC server on `localhost:845
 
 ```python
 >>> from eth_rpc_client import Client
->>> client = Client(host="127.0.0.1", port="8454")
+>>> client = Client(host="127.0.0.1", port="8545")
 >>> client.get_coinbase()
 ... '0xd3cda913deb6f67967b99d67acdfa1712c293601'
 ```


### PR DESCRIPTION
According to the specification and reference implementation of the Ethereum Go client the default port of the RPC endpoint is 8545, not 8454. See here: https://github.com/ethereum/wiki/wiki/JSON-RPC

http://ipfs.pics/QmWp2buQNoU1YYhu1K8Z9DyMx21nhKVN1YAvgzaQQuVJMn